### PR TITLE
fix for issue #1

### DIFF
--- a/com/infolace/format_base.clj
+++ b/com/infolace/format_base.clj
@@ -1534,7 +1534,8 @@ of parameters as well."
   (let [[raw-params [rest offset]] (extract-params s offset)
         [_ [rest offset flags]] (extract-flags rest offset)
         directive (first rest)
-        def (get directive-table (Character/toUpperCase #^Character directive))
+        ;; jimka, only attempt to get the def if we have a non-false directive
+        def (if directive (get directive-table (Character/toUpperCase #^Character directive)))
         params (if def (map-params def (map translate-param raw-params) flags offset))]
     (if (not directive)
       (format-error "Format string ended in the middle of a directive" offset))


### PR DESCRIPTION
Adding an `(if directive ...)` around the call `(get directive-table (Character/toUpperCase ^Character directive))` solves the problem and allows the error handling code to be reached.
